### PR TITLE
Feat : List 반환 API Map key로 사용할 id값 추가 반환되도록 수정.

### DIFF
--- a/src/main/java/ScreeningHumanity/MemberMypageServer/subscribe/entity/SubscribeEntity.java
+++ b/src/main/java/ScreeningHumanity/MemberMypageServer/subscribe/entity/SubscribeEntity.java
@@ -24,7 +24,7 @@ public class SubscribeEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    Long id;
+    private Long id;
 
     //구독 하는 사람의 uuid
     @Column(nullable = false)

--- a/src/main/java/ScreeningHumanity/MemberMypageServer/subscribe/service/implement/SubScribeServiceImp.java
+++ b/src/main/java/ScreeningHumanity/MemberMypageServer/subscribe/service/implement/SubScribeServiceImp.java
@@ -15,6 +15,7 @@ import ScreeningHumanity.MemberMypageServer.subscribe.service.SubscribeService;
 import ScreeningHumanity.MemberMypageServer.subscribe.vo.out.SubscribeOutVo;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -122,10 +123,12 @@ public class SubScribeServiceImp implements SubscribeService {
         List<SubscribeEntity> findData = subscribeJpaRepository.findAllBySubscribedNickNameAndStatus(
                 myNickName, SubscribeStatus.SUBSCRIBE);
 
+        AtomicLong indexId = new AtomicLong(1L);
         return findData.stream()
                 .map(data -> SubscribeOutVo.Follower
                         .builder()
                         .nickName(data.getSubscriberNickName())
+                        .id(indexId.getAndIncrement())
                         .build()
                 ).collect(Collectors.toList());
     }
@@ -135,10 +138,12 @@ public class SubScribeServiceImp implements SubscribeService {
         List<SubscribeEntity> findData = subscribeJpaRepository.findAllBySubscriberNickNameAndStatus(
                 myNickName, SubscribeStatus.SUBSCRIBE);
 
+        AtomicLong indexId = new AtomicLong(1L);
         return findData.stream()
                 .map(data -> SubscribeOutVo.Following
                         .builder()
                         .nickName(data.getSubscribedNickName())
+                        .id(indexId.getAndIncrement())
                         .build()
                 ).collect(Collectors.toList());
     }

--- a/src/main/java/ScreeningHumanity/MemberMypageServer/subscribe/vo/out/SubscribeOutVo.java
+++ b/src/main/java/ScreeningHumanity/MemberMypageServer/subscribe/vo/out/SubscribeOutVo.java
@@ -22,6 +22,7 @@ public class SubscribeOutVo {
     @NoArgsConstructor
     public static class Follower {
 
+        private Long id;
         private String nickName;
     }
 
@@ -31,6 +32,7 @@ public class SubscribeOutVo {
     @NoArgsConstructor
     public static class Following {
 
+        private Long id;
         private String nickName;
     }
 }


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) feat : pull request template#17-->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 패키징 구조 변경
- [ ] 파일명 변경
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용

<!--@{Issue번호} + Enter
ex) @17
이슈와 PR 연결을 위해 사용합니다!-->

#7 
- 팔로우, 팔로워 목록 조회 API 에 가상의 indexId 값을 생성하여 반환하도록 하였습니다.
- PK인 실제 Id값을 반환 하기에는 사용될 곳이 없어서 상기 내용처럼 처리하였습니다.

  <br/>

## 📈이미지 첨부
- 이미지 첨부가 필요한 경우 첨부 해주세요!
  <br/>
<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 과제

해당 이슈의 To do list를 작성 해주세요!
- [ ] Refresh Token 발급 절차 신규 적용 에정.
- [ ] User Login 절차 검증 로직 추가 및 리팩토링
